### PR TITLE
Handle collecting deep nested enums inside OpenApi document object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genum-openapi",
-  "version": "0.7.0",
+  "version": "0.8.0-alpha.0",
   "description": "Generate Typescript enums from openapi",
   "main": "./src/cli.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genum-openapi",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-alpha.1",
   "description": "Generate Typescript enums from openapi",
   "main": "./src/cli.ts",
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,6 +182,7 @@ const collectEnums = (schemas: OpenAPIV3.ComponentsObject["schemas"]) => {
     for (const key in schemaObject) {
       if (schemaObject[key].type === "object" && "properties" in schemaObject[key]) {
         collectRecursive(
+          // @ts-expect-error properties can be undefined
           schemaObject[key].properties,
           options.withParent ? (parentKey ? `${parentKey}__${key}` : key) : ""
         );
@@ -192,6 +193,7 @@ const collectEnums = (schemas: OpenAPIV3.ComponentsObject["schemas"]) => {
         !("$ref" in schemaObject[key])
       ) {
         const enumName = options.withParent && parentKey ? `${parentKey}__${key}` : key;
+        // @ts-expect-error schemaObject[key].enum can be undefined
         enumsMap.set(enumName, arrayToEnum(schemaObject[key].enum, enumName));
       }
     }
@@ -211,6 +213,7 @@ const collectEnums = (schemas: OpenAPIV3.ComponentsObject["schemas"]) => {
   //   }
   // }
 
+  // @ts-expect-error schemas don't fit the input object
   collectRecursive(schemas, "");
 
   return enumsMap;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,10 @@ program
   .option("--uppercase-names", "convert only exported enum names to uppercase ")
   .option("--uppercase-keys", "convert only enum keys to uppercase ")
   .option(
+    "--with-parent",
+    "when collecting enums preserve the parent object key within exported nested enum name"
+  )
+  .option(
     "-r, --custom-replacers <replacers>",
     // eslint-disable-next-line quotes
     'custom replacers applied during the normalization process, in JSON format, e.g. \'[{"regExp":"[-/]","replaceWith":"_"}]\''

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Options {
   prenum?: string;
   output: string;
   customReplacers?: string;
+  withParent?: boolean;
 }
 
 export interface Replacer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,21 @@
 import chalk from "chalk";
+import { OpenAPIV3 } from "openapi-types";
+
+type SchemaObject = OpenAPIV3.ArraySchemaObject | OpenAPIV3.NonArraySchemaObject;
+type ReferenceObject = OpenAPIV3.ReferenceObject;
 
 export function error(msg: string) {
   console.error(chalk.red(` ✘  ${msg}`));
 }
+
+export const isReferenceObject = (obj: object): obj is ReferenceObject => {
+  return obj && typeof obj === "object" && "$ref" in obj;
+};
+
+export const getCombinedSchemas = (
+  schemas: (SchemaObject | ReferenceObject) | (SchemaObject | ReferenceObject)[]
+) => {
+  return Array.isArray(schemas)
+    ? schemas.filter((item) => item !== undefined)
+    : [schemas].filter((item) => item !== undefined);
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -217,6 +217,20 @@ describe("CLI", () => {
       expect(stdout.trim()).toEqual(expected);
     });
 
+    test("should collect nested enums within anyOf, oneOf, allOf and not and preserve parent name with --with-parent flag", async () => {
+      const expected = fs
+        .readFileSync(new URL("./fixtures/output/enums_18.ts", import.meta.url), "utf-8")
+        .trim();
+      const { stdout } = await execa(
+        cmd,
+        ["test/fixtures/input/fixture_11.yaml", "--with-parent", "-n"],
+        {
+          cwd,
+        }
+      );
+      expect(stdout.trim()).toEqual(expected);
+    });
+
     test.todo("with not allowed --prenum", async () => {
       vi.mock("chalk", () => ({
         red: (text: string) => text,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -193,6 +193,30 @@ describe("CLI", () => {
       expect(stdout.trim()).toEqual(expected);
     });
 
+    test("should collect nested enums", async () => {
+      const expected = fs
+        .readFileSync(new URL("./fixtures/output/enums_16.ts", import.meta.url), "utf-8")
+        .trim();
+      const { stdout } = await execa(cmd, ["test/fixtures/input/fixture_10.yaml"], {
+        cwd,
+      });
+      expect(stdout.trim()).toEqual(expected);
+    });
+
+    test("should collect nested enums and preserve parent name with --with-parent flag", async () => {
+      const expected = fs
+        .readFileSync(new URL("./fixtures/output/enums_17.ts", import.meta.url), "utf-8")
+        .trim();
+      const { stdout } = await execa(
+        cmd,
+        ["test/fixtures/input/fixture_10.yaml", "--with-parent"],
+        {
+          cwd,
+        }
+      );
+      expect(stdout.trim()).toEqual(expected);
+    });
+
     test.todo("with not allowed --prenum", async () => {
       vi.mock("chalk", () => ({
         red: (text: string) => text,

--- a/test/fixtures/input/fixture_10.yaml
+++ b/test/fixtures/input/fixture_10.yaml
@@ -23,3 +23,11 @@ components:
           - ABORTED
           - FAILED
           - IN_PROGRESS
+        testOptions:
+          type: object
+          properties:
+            notification:
+              type: string
+              enum:
+              - NOTIFY
+              - NOT_NOTIFY

--- a/test/fixtures/input/fixture_10.yaml
+++ b/test/fixtures/input/fixture_10.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.1
+info:
+  title: Example OpenApi description
+  version: 0.0.0
+components:
+  schemas:
+    TestlogResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        testType:
+          type: string
+          enum:
+          - WEB
+          - MOBILE_ANDROID
+          - MOBILE_IOS
+        testResult:
+          type: string
+          enum:
+          - SUCCESSFUL
+          - ABORTED
+          - FAILED
+          - IN_PROGRESS

--- a/test/fixtures/input/fixture_11.yaml
+++ b/test/fixtures/input/fixture_11.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.3
+info:
+  title: Example OpenApi description
+  version: 0.0.0
+components:
+  schemas:
+    AgencyInvoicingType:
+      enum:
+        - INVOICE_PER_AGENCY
+        - INVOICE_PER_ACCOUNT
+      type: string
+    BaseObject:
+      type: object
+      properties:
+        baseProperty:
+          type: string
+          enum:
+            - BASE_VALUE1
+            - BASE_VALUE2
+    NestedObject:
+      type: object
+      properties:
+        nestedProperty:
+          type: string
+          enum:
+            - NESTED_VALUE1
+            - NESTED_VALUE2
+    ComplexObject:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        status:
+          type: string
+          enum:
+            - ACTIVE
+            - INACTIVE
+        details:
+          anyOf:
+            - type: string
+              enum:
+                - DETAIL_STRING1
+                - DETAIL_STRING2
+            - $ref: '#/components/schemas/NestedObject'
+        choices:
+          oneOf:
+            - type: string
+              enum:
+                - CHOICE1
+                - CHOICE2
+            - type: integer
+        attributes:
+          allOf:
+            - type: object
+              properties:
+                attribute1:
+                  type: string
+                  enum:
+                    - ATTR1_VALUE1
+                    - ATTR1_VALUE2
+            - $ref: '#/components/schemas/BaseObject'
+        notExample:
+          not:
+            type: string
+            enum:
+              - NOT_ALLOWED1
+              - NOT_ALLOWED2
+    TestObject:
+      type: object
+      properties:
+        testProperty:
+          type: string
+          enum:
+            - TEST_VALUE1
+            - TEST_VALUE2
+        complex:
+          $ref: '#/components/schemas/ComplexObject'
+    PaymentMethod:
+      required:
+        - type
+      description: >-
+        A Payment Method is a pure-virtual super-class that defines a specific
+        method of payment such as Direct Debit, Cash, Digital Wallet,Tokenized
+        Card, Bank Account Transfer, Bank Account Debit, Bank Card, Voucher,
+        Check, Bucket PaymentMethod, Account PaymentMethod, and Loyalty
+        PaymentMethod with all details associated. Use the @type attribute to
+        specify the concrete type in the API calls.
+      allOf:
+        - $ref: '#/components/schemas/BaseObject'
+        - type: object
+          properties:
+            type:
+              type: string
+              description: 'Type of payment method (e.g.: bank card, cash, voucher, etc).'
+              enum:
+                - none
+                - cash
+                - online
+                - bank-transfer
+                - token-online

--- a/test/fixtures/output/enums_16.ts
+++ b/test/fixtures/output/enums_16.ts
@@ -1,0 +1,18 @@
+export enum testType {
+  WEB = "WEB",
+  MOBILE_ANDROID = "MOBILE_ANDROID",
+  MOBILE_IOS = "MOBILE_IOS"
+}
+
+export enum testResult {
+  SUCCESSFUL = "SUCCESSFUL",
+  ABORTED = "ABORTED",
+  FAILED = "FAILED",
+  IN_PROGRESS = "IN_PROGRESS"
+}
+
+export enum notification {
+  NOTIFY = "NOTIFY",
+  NOT_NOTIFY = "NOT_NOTIFY"
+}
+

--- a/test/fixtures/output/enums_17.ts
+++ b/test/fixtures/output/enums_17.ts
@@ -1,0 +1,18 @@
+export enum TestlogResponse__testType {
+  WEB = "WEB",
+  MOBILE_ANDROID = "MOBILE_ANDROID",
+  MOBILE_IOS = "MOBILE_IOS"
+}
+
+export enum TestlogResponse__testResult {
+  SUCCESSFUL = "SUCCESSFUL",
+  ABORTED = "ABORTED",
+  FAILED = "FAILED",
+  IN_PROGRESS = "IN_PROGRESS"
+}
+
+export enum TestlogResponse__testOptions__notification {
+  NOTIFY = "NOTIFY",
+  NOT_NOTIFY = "NOT_NOTIFY"
+}
+

--- a/test/fixtures/output/enums_18.ts
+++ b/test/fixtures/output/enums_18.ts
@@ -1,0 +1,53 @@
+export enum AgencyInvoicingType {
+  INVOICE_PER_AGENCY = "INVOICE_PER_AGENCY",
+  INVOICE_PER_ACCOUNT = "INVOICE_PER_ACCOUNT"
+}
+
+export enum BaseObject__baseProperty {
+  BASE_VALUE1 = "BASE_VALUE1",
+  BASE_VALUE2 = "BASE_VALUE2"
+}
+
+export enum NestedObject__nestedProperty {
+  NESTED_VALUE1 = "NESTED_VALUE1",
+  NESTED_VALUE2 = "NESTED_VALUE2"
+}
+
+export enum ComplexObject__status {
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE"
+}
+
+export enum ComplexObject__details {
+  DETAIL_STRING1 = "DETAIL_STRING1",
+  DETAIL_STRING2 = "DETAIL_STRING2"
+}
+
+export enum ComplexObject__choices {
+  CHOICE1 = "CHOICE1",
+  CHOICE2 = "CHOICE2"
+}
+
+export enum ComplexObject__attributes__attribute1 {
+  ATTR1_VALUE1 = "ATTR1_VALUE1",
+  ATTR1_VALUE2 = "ATTR1_VALUE2"
+}
+
+export enum ComplexObject__notExample {
+  NOT_ALLOWED1 = "NOT_ALLOWED1",
+  NOT_ALLOWED2 = "NOT_ALLOWED2"
+}
+
+export enum TestObject__testProperty {
+  TEST_VALUE1 = "TEST_VALUE1",
+  TEST_VALUE2 = "TEST_VALUE2"
+}
+
+export enum PaymentMethod__type {
+  none = "none",
+  cash = "cash",
+  online = "online",
+  bank_transfer = "bank-transfer",
+  token_online = "token-online"
+}
+

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,24 @@
 import { vi, describe, test, expect } from "vitest";
-import { error } from "../src/utils";
+import { error, getCombinedSchemas, isReferenceObject } from "../src/utils";
 import chalk from "chalk";
+import { OpenAPIV3 } from "openapi-types";
 
 vi.mock("chalk");
+
+const notObject: OpenAPIV3.SchemaObject = {
+  type: "string",
+  enum: ["NOT_ALLOWED1", "NOT_ALLOWED2"],
+};
+
+const anyOfArray: (OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject)[] = [
+  {
+    type: "string",
+    enum: ["DETAIL_STRING1", "DETAIL_STRING2"],
+  },
+  {
+    $ref: "#/components/schemas/NestedObject",
+  },
+];
 
 describe("utils", () => {
   test("error", () => {
@@ -13,5 +29,33 @@ describe("utils", () => {
 
     expect(chalk.red).toHaveBeenCalledWith(` ✘  ${msg}`);
     expect(consoleErrorSpy).toHaveBeenCalledWith(`RED( ✘  ${msg})`);
+  });
+
+  test("isReferenceObject", () => {
+    expect(isReferenceObject({ $ref: "#/components/schemas/ComplexObject" })).toBe(true);
+    expect(
+      isReferenceObject({
+        type: "object",
+        properties: {
+          testResult: {
+            type: "string",
+            enum: ["SUCCESSFUL", "ABORTED", "FAILED", "IN_PROGRESS"],
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  test("getCombinedSchemas", () => {
+    expect(getCombinedSchemas(notObject)).toEqual([notObject]);
+    expect(getCombinedSchemas(anyOfArray)).toEqual([
+      {
+        type: "string",
+        enum: ["DETAIL_STRING1", "DETAIL_STRING2"],
+      },
+      {
+        $ref: "#/components/schemas/NestedObject",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Extended function for collecting enums to properly deal with deep nested enums. 
Added `--with-parent` option to keep the parent key within exported enum name. 